### PR TITLE
Sprint and double jump RGv1

### DIFF
--- a/src/Arachnivania/project.godot
+++ b/src/Arachnivania/project.godot
@@ -96,6 +96,12 @@ pause={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
+sprint={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
 
 [layer_names]
 

--- a/src/Arachnivania/src/Actors/Widower/Camera/CameraRig.tscn
+++ b/src/Arachnivania/src/Actors/Widower/Camera/CameraRig.tscn
@@ -7,23 +7,14 @@
 script = ExtResource( 1 )
 
 [node name="ShakingCamera" parent="." instance=ExtResource( 2 )]
-current = true
 process_mode = 0
-smoothing_enabled = true
-smoothing_speed = 3.0
 drag_margin_left = 0.0
 drag_margin_top = 0.0
 drag_margin_right = 0.0
 drag_margin_bottom = 0.0
-amplitude = 8.0
-duration = 0.8
 default_smoothing_speed = {
 "gamepad": 1,
 "mouse": 3
 }
-
-[node name="Timer" parent="ShakingCamera" index="0"]
-wait_time = 0.8
-one_shot = true
 
 [editable path="ShakingCamera"]

--- a/src/Arachnivania/src/Actors/Widower/States/Air.gd
+++ b/src/Arachnivania/src/Actors/Widower/States/Air.gd
@@ -1,15 +1,23 @@
 extends State
 """
-Vertical and Horizontal movement in the air.
-Delegates movement to its parent Move state and extends it
-with state transitions
+Manages Air movement, including jumping and landing.
+You can pass a msg to this state, every key is optional:
+{
+	velocity: Vector2, to preseve inertia from the previos state
+	impulse: float, to make the character jump
+}
 """
 #Configurable properties
 export var acceleration_x: = 2500.0
+export var jump_impulse: = 450.0
+export var max_jump_count:= 2
+var _jump_count: = 0
 
 #Base interface function from state, delegates to Move
 func unhandled_input(event: InputEvent) -> void:
 	var move: = get_parent()
+	if event.is_action_pressed("jump") and _jump_count < max_jump_count:
+		jump()
 	move.unhandled_input(event)
 
 #Base interface function from state, defines Air and transitions
@@ -34,15 +42,24 @@ func enter(msg: Dictionary = {}) -> void:
 		move.max_speed.x = max(abs(msg.velocity.x), move.max_speed_default.x)
 	#Ability to jump, using other states to tell Air the player needs to jump
 	if "impulse" in msg:
-		move.velocity += calculate_jump_velocity(msg.impulse)
+		jump()
 
 #Base interface function from state to delegate to the parent state Move
 func exit() -> void:
 	var move: = get_parent()
-	move.exit()
 	#Resets acceleration to default on exiting move state
 	move.acceleration = move.acceleration_default
+	#Reset _jump_count
+	_jump_count = 0
+	move.exit()
 
+#Handles jump velocity and double jump
+func jump() -> void:
+	var move: = get_parent()
+	move.velocity += calculate_jump_velocity(jump_impulse)
+	_jump_count += 1
+
+#Returns a new velocity with a vertical impulse added it it
 func calculate_jump_velocity(impulse: = 0.0) -> Vector2:
 	var move: = get_parent()
 	return move.calculate_velocity(

--- a/src/Arachnivania/src/Actors/Widower/States/Air.gd
+++ b/src/Arachnivania/src/Actors/Widower/States/Air.gd
@@ -1,5 +1,9 @@
 extends State
-
+"""
+Vertical and Horizontal movement in the air.
+Delegates movement to its parent Move state and extends it
+with state transitions
+"""
 #Configurable properties
 export var acceleration_x: = 2500.0
 

--- a/src/Arachnivania/src/Actors/Widower/States/Move.gd
+++ b/src/Arachnivania/src/Actors/Widower/States/Move.gd
@@ -9,7 +9,7 @@ Children move states can delegate movement to it, or use its utility function
 #Exported variables that can be configured
 export var max_speed_default: = Vector2(135.0, 230.0)
 export var acceleration_default: = Vector2(50000.0, 1500.0)
-export var jump_impulse: = 450.0
+export var max_speed_fall: = 1500.0
 
 #Public properties that the states can manipulate
 var acceleration: = acceleration_default
@@ -19,7 +19,7 @@ var velocity: = Vector2.ZERO
 #adding a transition to the air state when input is detected
 func unhandled_input(event: InputEvent) -> void:
 	if owner.is_on_floor() and event.is_action_pressed("jump"):
-		_state_machine.transition_to("Move/Air", { impulse = jump_impulse})
+		_state_machine.transition_to("Move/Air", { impulse = true})
 
 #default physics_process from that will be defined by movement states
 #owner calls the parent node
@@ -37,14 +37,15 @@ static func calculate_velocity(
 		max_speed: Vector2,
 		acceleration: Vector2,
 		delta: float,
-		move_direction: Vector2
+		move_direction: Vector2,
+		max_speed_fall: = 1500.0
 	) -> Vector2:
 	var new_velocity: = old_velocity
 	#steer towards the players intended direction
 	new_velocity += move_direction * acceleration * delta
 	#clamp velocity on both x and y axis
 	new_velocity.x = clamp(new_velocity.x, -max_speed.x, max_speed.x)
-	new_velocity.y = clamp(new_velocity.y, -max_speed.y, max_speed.y)
+	new_velocity.y = clamp(new_velocity.y, -max_speed.y, max_speed_fall)
 	return new_velocity
 
 #function to get movement direction and return a vector2

--- a/src/Arachnivania/src/Actors/Widower/States/Run.gd
+++ b/src/Arachnivania/src/Actors/Widower/States/Run.gd
@@ -1,4 +1,10 @@
 extends State
+"""
+Horizontal movement on the ground.
+Delegates movement to its parent Move state and extends it
+with state transitions
+"""
+export var max_speed_sprint: = 243.0
 
 #Base interface function from state, delegates to Move
 func unhandled_input(event: InputEvent) -> void:
@@ -8,6 +14,11 @@ func unhandled_input(event: InputEvent) -> void:
 #Base interface function from state, defines Run and transitions
 func physics_process(delta: float) -> void:
 	var move: = get_parent()
+	#Set max_speed based on whether sprint is pressed or not
+	if Input.is_action_pressed("sprint"):
+		move.max_speed.x = max_speed_sprint
+	else:
+		move.max_speed.x = move.max_speed_default.x
 	#Transitions to other states based on direction and position
 	if owner.is_on_floor() and move.get_move_direction().x == 0.0:
 		_state_machine.transition_to("Move/Idle")

--- a/src/Arachnivania/src/Main/Game.tscn
+++ b/src/Arachnivania/src/Main/Game.tscn
@@ -95,7 +95,6 @@ offset = Vector2( 150, 150 )
 
 [node name="Move" parent="Player/StateMachine" index="0"]
 acceleration_default = Vector2( 5000, 500 )
-jump_impulse = 190.0
 
 [editable path="CanvasLayer/DebugDock/Column/DebugPanel"]
 


### PR DESCRIPTION
@rngoode1
Added Sprint …
733751e
* Created new input `"sprint"` and assigned it to sprint and LT
* Added `export var max_speed_sprint` and set it to `243.0`
* Added code to `physics_process()` that checks if `"sprint"` is pressed
  and sets `move.max_speed.x` accordingly.
* Added additional comments to `Run` and `Air` states

@rngoode1
Additional comments to Air state
8bdb243

@rngoode1
Double Jump …
8c8dd7c
* Moved `jump_impulse` to `Air` state from `Move`
* Added an export var `max_jump_count` and set it to `2` in the `Air` state
* Add private var to `Air`: `_jump_count` and set to `0`
* Added `jump()` function to `Air` that handles the double jump counter and calls `calculate_jump_velocity` to set `move.velocity`
* Modified `Air.unhandled_input()` to handle the new `jump()` function.
* Modified `Air.enter()` function for `"impulse"` msg block to just call `jump()`
* Modified `Air.exit()` to reset `_jump_count` on exit
* Added export var `max_speed_fall` to `Move` state and lowered `max_speed_default.y` to better balance the double jump
* Modified `Move.physics_process` to just pass `{impulse = true}` instead of var `jump_impulse` since that variable moved to `Air`
* Modified `Move.calculate_velocity` to accept `max_speed_fall` as a parameter and use it as the downward `clamp()` value in the `return.y` value


https://user-images.githubusercontent.com/33633342/114319807-09f06280-9ae1-11eb-8d90-1766a05c946c.mp4

